### PR TITLE
7.8 Fixes and Warp fixes

### DIFF
--- a/src/MFlow/Wai/Blaze/Html/All.hs
+++ b/src/MFlow/Wai/Blaze/Html/All.hs
@@ -1,4 +1,4 @@
------------------------------------------------------------------------------
+----------------------------------------------------------------------------
 --
 -- Module      :  MFlow.Wai.Blaze.Html.All
 -- Copyright   :
@@ -40,7 +40,7 @@ import MFlow.Forms.Cache
 import Text.Blaze.Html5 hiding (map)
 import Text.Blaze.Html5.Attributes  hiding (label,span,style,cite,title,summary,step,form)
 import Network.Wai
-import Network.Wai.Handler.Warp(run,defaultSettings,Settings,settingsPort)
+import Network.Wai.Handler.Warp(run,defaultSettings,Settings,setPort)
 import Data.TCache
 import Text.Blaze.Internal(text)
 
@@ -83,7 +83,7 @@ runNavigation n f= do
     --runSettings defaultSettings{settingsTimeout = 20, settingsPort= porti} waiMessageFlow
 
 -- | Exactly the same as runNavigation, but with TLS added.
--- | Expects certificate.pem and key.pem in project directory.
+-- Expects certificate.pem and key.pem in project directory.
 
 runSecureNavigation = runSecureNavigation' TLS.defaultTlsSettings defaultSettings
 
@@ -92,4 +92,5 @@ runSecureNavigation' t s n f = do
     unless (null n) $ setNoScript n
     addMessageFlows[(n, runFlow f)]
     porti <- getPort
-    wait $ TLS.runTLS t s{settingsPort = porti} waiMessageFlow
+    let s' = setPort porti s
+    wait $ TLS.runTLS t s' waiMessageFlow


### PR DESCRIPTION
It seems that the new Typeable class (new in ghc 7.7) does not like having custom instances. The docs say to just derive it.

[ 9 of 13] Compiling MFlow.Forms.Widgets ( src/MFlow/Forms/Widgets.hs, dist/build/MFlow/Forms/Widgets.o )

src/MFlow/Forms/Widgets.hs:111:3:
    ‘typeOf’ is not a (visible) method of class ‘Typeable’

I went ahead and commented lines 110-121 and just derived it and peppered all the neccessary Typeable constraints, and everything seems to compile well, now test are needed. Also fixed some random stuff to do with Network.Wai.Handler.Warp.Settings.

Although this still breaks:

Demos/Menu.hs:28:8:
    Could not find module ‘Text.Hamlet’
    It is a member of the hidden package ‘shakespeare-2.0.0.1’.
    Perhaps you need to add ‘shakespeare’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
