### PR TITLE
Case for handling implicit/explicit forms with <|>

### DIFF
--- a/src/MFlow/Forms/Internals.hs
+++ b/src/MFlow/Forms/Internals.hs
@@ -1556,9 +1556,10 @@ insertForm w=View $ do
 controlForms :: (FormInput v, MonadState (MFlowState v) m)
     => MFlowState v -> MFlowState v -> v -> v -> m (v,Bool)
 controlForms s1 s2 v1 v2= case (needForm s1, needForm s2) of
---    (HasForm,HasElems) -> do
---       v2' <- formPrefix s2 v2 True
---       return (v1 ++ [v2'], True)
+    (HasForm,HasElems) -> do
+      v2' <- formPrefix s2 v2 True
+      return (v1 <> v2', True)
+
     (HasElems, HasForm) -> do
        v1' <- formPrefix s1 v1 True
        return (v1' <> v2 , True)


### PR DESCRIPTION
``` haskell
test = step $ do
  i <- page $
         (wform $ getInt (Just 1)) <! [("class", "foo")]
       <|> do
             submitButton "ok"
             --noWidget -- works if there is widget that does not produce HasElems
             return 0

  page $ p "hola" ++> noWidget
```

In above case, my explicit form laters gets removed and replaced by implicit one (it manifests with removal of `class main-form`). I've tracked this to the `controlForms` function, and noticed some commented out code - why was that, and is this pull request correct then? (In my case it is).
