### PR TITLE
Correct order for updateParams

### DIFF
--- a/src/MFlow/Forms.hs
+++ b/src/MFlow/Forms.hs
@@ -1145,8 +1145,8 @@ nextMessage = do
      updateParams False _ req= req
      updateParams True env req=
         let old= takeWhile isparam  env
-            (new,rest)= Data.List.break isparam  req
-            parms= new ++ rest ++ old
+            (new,rest)= Data.List.span isparam  req
+            parms= new++ old++ rest
         
 --        let params= takeWhile isparam  env
 --            fs= fst $ head req


### PR DESCRIPTION
The fix introduced by cf610f5 broke the validation/submission -
after submitting invalid value, it was not possible to update it,
as the old value was taking a precedence.

I do not know if it is optimal fix, but it does the trick.
