### PR TITLE
Three compile-errors in b2c039bbe23af22f8a6eb66d55af7c616583c364

### DIFF
--- a/Demos/MFlowPersistent.hs
+++ b/Demos/MFlowPersistent.hs
@@ -17,6 +17,8 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE CPP #-}
 
 module MFlowPersistent
@@ -25,6 +27,7 @@ where
 
 
 import           Control.Monad.IO.Class  (liftIO)
+import           Control.Monad.Logger
 import           Database.Persist
 import           Database.Persist.Sqlite
 import           Database.Persist.TH
@@ -56,7 +59,7 @@ BlogPost
 
 
 
-pool= unsafePerformIO $ createSqlitePool ":memory:" 10
+pool= unsafePerformIO $ runNoLoggingT( createSqlitePool ":memory:" 10 )
 
 runSQL sql= liftIO $  runSqlPersistMPool sql pool
 


### PR DESCRIPTION
when trying to cabal build Demos

  1) Demos/MFlowPersistent.hs:47:1:  Illegal instance declaration for
  ‘ToBackendKey SqlBackend BlogPost’
    - add MultiParamTypeClasses

  2) Demos/MFlowPersistent.hs:48:1:
      Can't make a derived instance of
      ‘path-pieces-0.1.5:Web.PathPieces.PathPiece (Key Person)’:
      ‘path-pieces-0.1.5:Web.PathPieces.PathPiece’ is not a derivable
      class
    - add GeneralizedNewtypeDeriving

  3) Demos/MFlowPersistent.hs:59:25:
      No instance for (Control.Monad.Logger.MonadLogger IO)
      arising from a use of ‘createSqlitePool’
    - wrap in runNoLoggingT

~

ghc --version:
The Glorious Glasgow Haskell Compilation System, version 7.8.3